### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the daemontools cookbo
 
 ## Unreleased
 
+- resolved cookstyle error: recipes/svscan.rb:26:6 refactor: `Chef/Modernize/UseChefLanguageSystemdHelper`
+- resolved cookstyle error: resources/service.rb:160:1 refactor: `Chef/Modernize/ClassEvalActionClass`
 ## 1.6.3 - *2021-08-29*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is used to list changes made in each version of the daemontools cookbo
 
 - resolved cookstyle error: recipes/svscan.rb:26:6 refactor: `Chef/Modernize/UseChefLanguageSystemdHelper`
 - resolved cookstyle error: resources/service.rb:160:1 refactor: `Chef/Modernize/ClassEvalActionClass`
+
 ## 1.6.3 - *2021-08-29*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/recipes/svscan.rb
+++ b/recipes/svscan.rb
@@ -23,7 +23,7 @@ directory 'daemontools service directory' do
 end
 
 if node['daemontools']['install_method'] == 'source'
-  if node['init_package'] == 'systemd'
+  if systemd?
     template '/usr/lib/systemd/system/daemontools.service' do
       source 'daemontools.service.erb'
       variables(

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -157,7 +157,7 @@ SVC_ACTIONS.each do |act, opt|
   end
 end
 
-action_class.class_eval do
+action_class do
   def shell_out_with_systems_locale(command, **opts)
     options = { environment: { 'LC_ALL' => nil } }.merge(opts)
     shell_out(command, **options)


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.25.6 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with recipes/svscan.rb

 - 26:6 refactor: `Chef/Modernize/UseChefLanguageSystemdHelper` - Chef Infra Client 15.5 and later include a `systemd?` helper for checking if a Linux system uses systemd. (https://docs.chef.io/workstation/cookstyle/chef_modernize_usecheflanguagesystemdhelper)

### Issues found and resolved with resources/service.rb

 - 160:1 refactor: `Chef/Modernize/ClassEvalActionClass` - In Chef Infra Client 12.9 and later it is no longer necessary to call the class_eval method on the action class block. (https://docs.chef.io/workstation/cookstyle/chef_modernize_classevalactionclass)